### PR TITLE
fix: use client navigation for docs links

### DIFF
--- a/src/components/Header/Categories.tsx
+++ b/src/components/Header/Categories.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation"
 import clsx from "clsx";
 import { categories } from "@/sidebars";
+import Link from "next/link";
 
 export default function Categories() {
     const pathname = usePathname();
@@ -19,7 +20,7 @@ export default function Categories() {
     return (<ul className="flex gap-[32px] text-[14px] leading-[30px] pt-[12px] text-[var(--text-secondary)] text-center">
         {cs.map((c) => (
             <li key={c.label}>
-                <a
+                <Link
                     href={c.link}
                     className={clsx([
                         "inline-block hover:text-[var(--text-primary)]",
@@ -30,7 +31,7 @@ export default function Categories() {
                     ])}
                 >
                     {c.label}
-                </a>
+                </Link>
             </li>
         ))}
     </ul>)

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect } from "react"
 import { LuMenu, LuX } from "react-icons/lu"
 import Sidebar from "@/components/Sidebar"
 import Image from "next/image"
+import Link from "next/link"
 
 export default function MobileNav() {
     const currentPath = usePathname()
@@ -184,16 +185,16 @@ export default function MobileNav() {
                             </h3>
                             <div className="space-y-1">
                                 {cs.map((c) => (
-                                    <a key={c.link} href={c.link} onClick={() => setIsOpen(false)} className={
+                                    <Link key={c.link} href={c.link} onClick={() => setIsOpen(false)} className={
                                         clsx(
                                             "flex items-center py-2.5 px-3 text-sm rounded-lg transition-colors duration-200",
                                             c.isCurrent
                                                 ? "bg-[rgba(0,0,0,0.04)] text-[var(--text-primary)] font-medium"
                                                 : "text-[var(--text-secondary)] hover:bg-[rgba(0,0,0,0.02)] hover:text-[var(--text-primary)]"
-                                        )}
+                                    )}
                                     >
                                         <span className="flex-1">{c.label}</span>
-                                    </a>
+                                    </Link>
                                 ))}
                             </div>
                         </div>

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -4,6 +4,7 @@ import { usePathname } from "next/navigation"
 import { ConfigProvider, Menu, type MenuProps } from 'antd';
 import { getSidebar, SidebarItem } from "@/sidebars";
 import { useState } from "react";
+import Link from "next/link";
 
 type MenuItem = Required<MenuProps>['items'][number];
 
@@ -28,7 +29,7 @@ export default function Sidebar({ prefix, className }: { prefix: string, classNa
 
             return {
                 key: key,
-                label: <>{item.link ? <a href={item.link}>{item.label}</a> : item.label}</>,
+                label: <>{item.link ? <Link href={item.link}>{item.label}</Link> : item.label}</>,
                 children: children.length > 0 ? children : undefined,
             }
         })
@@ -120,4 +121,3 @@ export default function Sidebar({ prefix, className }: { prefix: string, classNa
         />
     </ConfigProvider>
 }
-


### PR DESCRIPTION
## Summary

- replace internal docs category/sidebar anchors with Next.js Link components
- keep docs navigation inside the App Router client transition path

## Why

Internal docs navigation was using native anchors in the top category nav, desktop sidebar menu, and mobile category drawer. Those clicks performed full document navigations, causing the root header, logo, and DocSearch box to remount when switching panels/pages.

## Validation

- pnpm build
- local browser network check: sidebar and top category clicks produced zero additional document requests