### PR TITLE
docs: reorganize SDK guides

### DIFF
--- a/src/content/developer/go.mdx
+++ b/src/content/developer/go.mdx
@@ -1,6 +1,8 @@
 ---
 title: Go SDK
 relatedContents:
+    - title: SDKs
+      url: /developer/sdks
     - title: Connect an application
       url: /guides/connect-to-scopedb
     - title: HTTP API
@@ -9,19 +11,19 @@ relatedContents:
       url: https://github.com/scopedb/scopedb-sdk/tree/main/go
 ---
 
-Use the Go SDK to execute ScopeQL statements from server-side Go applications.
+Use the Go SDK from server-side Go applications.
 
 ## Before you start
 
-Use Go 1.24 or later. Set the ScopeDB API address and API key copied from
-**Connect** in ScopeDB Console:
+Use Go 1.24 or later. Follow [Connect an application](/guides/connect-to-scopedb),
+then set the endpoint and API key used by the examples:
 
 ```bash
 export SCOPEDB_ENDPOINT="https://<endpoint>"
 export SCOPEDB_API_KEY="<api-key>"
 ```
 
-## 1. Install the SDK
+## Install
 
 From your Go module, run:
 
@@ -29,55 +31,73 @@ From your Go module, run:
 go get github.com/scopedb/scopedb-sdk/go
 ```
 
-## 2. Create a client and run a statement
+## Create a client
 
 ```go
-package main
+client := scopedb.NewClient(&scopedb.Config{
+	Endpoint: os.Getenv("SCOPEDB_ENDPOINT"),
+	APIKey:   os.Getenv("SCOPEDB_API_KEY"),
+})
+defer client.Close()
+```
 
-import (
-	"context"
-	"fmt"
-	"log"
-	"os"
-	"time"
+Create the client once and reuse it for requests from your application.
 
-	"github.com/scopedb/scopedb-sdk/go"
-)
+## Execute a statement
 
-func main() {
-	client := scopedb.NewClient(&scopedb.Config{
-		Endpoint: os.Getenv("SCOPEDB_ENDPOINT"),
-		APIKey:   os.Getenv("SCOPEDB_API_KEY"),
-	})
-	defer client.Close()
+```go
+ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+defer cancel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
-	result, err := client.Statement("SELECT 1 AS ok").Execute(ctx)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	rows, err := result.ToValues()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	fmt.Println(rows)
+result, err := client.Statement("SELECT 1 AS ok").Execute(ctx)
+if err != nil {
+	log.Fatal(err)
 }
 ```
 
-`Execute` submits the statement and polls until it finishes, fails, or is
-cancelled. It returns early if the context is cancelled or reaches its deadline.
-Cancelling the context stops client-side requests and polling; it does not cancel
-the statement in ScopeDB. `ToValues` converts binary cells to `[]byte`, timestamps
-to `time.Time`, fixed-duration intervals to `time.Duration`, and `null` to `nil`.
-Array, object, and `any` cells remain JSON strings.
+`Execute` returns a finished result or an error. It handles an active
+statement's polling internally and returns early when the context is cancelled
+or reaches its deadline.
 
-For direct control over submission and polling, use `Submit` to obtain a
-`StatementHandle`. Call `FetchOnce` and then inspect `Status`, `Progress`, or
-`ResultSet`, or call `Fetch` to poll until completion. To cancel the statement in
-ScopeDB, call `Cancel` on the handle. See the
-[HTTP API guide](/developer/http-api) for the underlying statement-state contract
-and ingest behavior.
+## Work with results
+
+Use `ToValues` to convert JSON result cells to Go values:
+
+```go
+rows, err := result.ToValues()
+if err != nil {
+	log.Fatal(err)
+}
+
+fmt.Println(rows)
+```
+
+The current conversions are:
+
+| ScopeDB value | Go value |
+| --- | --- |
+| `binary` | `[]byte` |
+| `timestamp` | `time.Time` |
+| Fixed-duration `interval` | `time.Duration` |
+| `null` | `nil` |
+| `array`, `object`, or `any` | JSON string |
+
+## Control statement execution
+
+Use `Submit` when you need direct control over a `StatementHandle`. `FetchOnce`
+updates its status once, `Fetch` waits for a terminal result, and `Status`,
+`Progress`, and `ResultSet` expose the last response.
+
+Cancelling the Go context stops client-side requests and polling; it does not
+cancel the statement in ScopeDB. Call `Cancel` on the handle to request
+server-side cancellation. See the [HTTP API](/developer/http-api) for the
+underlying state and cancellation contract.
+
+## Next steps
+
+- Build application queries with [Query data](/guides/query-events).
+- Follow [Ingest data](/guides/ingest-events) for the current write workflow.
+- Review statement states, errors, and retries in the
+  [HTTP API](/developer/http-api).
+- Browse the [Go SDK repository](https://github.com/scopedb/scopedb-sdk/tree/main/go)
+  for the complete package surface.

--- a/src/content/developer/index.mdx
+++ b/src/content/developer/index.mdx
@@ -4,31 +4,31 @@ title: Developer
 
 Build applications and tools on ScopeDB from your backend.
 
-Start by connecting to a workspace, then choose the interface that fits your
-application and language.
+Start by connecting to a workspace, then choose an SDK, the HTTP API, or the
+ScopeQL CLI.
 
-## Start here
+## Connect to ScopeDB
 
 ### [Connect an application](/guides/connect-to-scopedb)
 
 Get your endpoint and API key, set environment variables, and send a test
 request.
 
-### [Node.js SDK](/developer/nodejs)
+## Choose an interface
 
-Query ScopeDB and send batched JSON events from TypeScript or JavaScript.
+### [SDKs](/developer/sdks)
 
-### [Go SDK](/developer/go)
+Build backend applications with the Node.js or Go SDK. Start with the SDK
+overview, then follow the task-based guide for your language.
 
-Execute ScopeQL statements from Go applications.
+### [HTTP API](/developer/http-api)
+
+Call ScopeDB from another backend runtime or control requests and statement
+polling directly.
 
 ### [ScopeQL CLI](/developer/scopeql-cli)
 
 Run ScopeDB from a terminal, script, or CI job.
-
-### [HTTP API](/developer/http-api)
-
-Call ScopeDB from any backend service with `/v1/statements` and `/v1/ingest`.
 
 ## Common rules
 
@@ -36,8 +36,6 @@ Whichever interface you choose:
 
 - keep the ScopeDB API key in server-side secret storage;
 - use the ScopeDB API address copied from **Connect** in Console;
-- treat `finished` as the only successful terminal statement state;
-- retain statement IDs while polling or troubleshooting;
 - bound application queries and validate any user-controlled inputs.
 
 For local exploration or scripts, use the [ScopeQL CLI](/developer/scopeql-cli).

--- a/src/content/developer/nodejs.mdx
+++ b/src/content/developer/nodejs.mdx
@@ -1,32 +1,37 @@
 ---
 title: Node.js SDK
 relatedContents:
+    - title: SDKs
+      url: /developer/sdks
     - title: Connect an application
       url: /guides/connect-to-scopedb
-    - title: Query data
-      url: /guides/query-events
     - title: HTTP API
       url: /developer/http-api
+    - title: Node.js SDK repository
+      url: https://github.com/scopedb/scopedb-js
 ---
 
-Use the Node.js SDK from server-side JavaScript or TypeScript applications.
+Use the Node.js SDK from server-side TypeScript or JavaScript applications.
 
 ## Before you start
 
-Use Node.js 20 or later. Set your ScopeDB endpoint and API key:
+Use Node.js 20 or later. Follow [Connect an application](/guides/connect-to-scopedb),
+then set the endpoint and API key used by the examples:
 
 ```bash
 export SCOPEDB_ENDPOINT="https://<endpoint>"
 export SCOPEDB_API_KEY="<api-key>"
 ```
 
-## 1. Install the SDK
+## Install
 
 ```bash
-pnpm install scopedb
+pnpm add scopedb
 ```
 
-## 2. Create a client
+The package is ESM-only. Import it with ES module syntax as shown below.
+
+## Create a client
 
 ```ts
 import { Client } from "scopedb";
@@ -44,7 +49,7 @@ const client = new Client(endpoint, { token: apiKey });
 Keep the API key on the server. Do not create authenticated ScopeDB clients in
 browser code.
 
-## 3. Run a statement
+## Execute a statement
 
 ```ts
 const result = await client
@@ -55,58 +60,73 @@ const result = await client
     LIMIT 10
   `)
   .execute();
-
-console.log(result.intoObjects());
 ```
 
-## 4. Send batched JSON events
+`execute()` returns a finished result or throws when execution fails, is
+cancelled, or the request is aborted. It handles an active statement's polling
+internally.
+
+## Work with results
+
+For most application code, convert rows to objects keyed by column name:
 
 ```ts
-const stream = client
-  .ingestStream(`
-    SELECT
-      $0['time']::timestamp AS time,
-      $0['service']::string AS service,
-      $0['name']::string AS name,
-      $0::object AS var
-    WHERE service IS NOT NULL
-      AND name IS NOT NULL
-    INSERT INTO events
-  `)
-  .build();
-
-await stream.send({
-  time: new Date().toISOString(),
-  service: "checkout",
-  name: "checkout_started",
-  region: "apac",
-});
-
-await stream.flush();
-await stream.shutdown();
+const rows = result.intoObjects();
+console.log(rows[0]);
 ```
 
-Use a long-lived stream for batches that share the same transformation. Always
-call `shutdown()` when you are done; it flushes remaining records before closing,
-so the explicit `flush()` above is only a checkpoint.
+Use `first()` for a lookup or aggregate that returns at most one row, and
+`intoValues()` when positional arrays are more convenient.
 
-The stream retries transient failures. Because an ingest response can be lost
-after rows are accepted, a retry may insert the same row again. Include a stable
-event identifier when your application needs to detect replays.
-
-## Handle integers before returning JSON
-
-ScopeDB integer values may exceed JavaScript's safe integer range. The SDK uses
-`bigint` by default for lossless values, but `bigint` is not JSON-serializable.
-
-Convert rows at your application boundary:
+ScopeDB integers can exceed JavaScript's safe integer range. The SDK returns
+them as `bigint` by default, which preserves precision but cannot be passed to
+`JSON.stringify` directly. Choose the representation at the application
+boundary:
 
 ```ts
-const rows = result.intoObjects({ integerMode: "string" });
+const jsonSafeRows = result.intoObjects({ integerMode: "string" });
 ```
 
 Use:
 
-- `bigint` when you need exact arithmetic in JavaScript;
-- `string` when you need JSON-safe identifiers or counters;
-- `number` only when the values fit inside `Number.MAX_SAFE_INTEGER`.
+- `bigint` for lossless JavaScript arithmetic;
+- `string` for JSON-safe identifiers or unbounded counters;
+- `number` only when values fit within JavaScript's safe integer range.
+
+## Control statement execution
+
+Use `submit()` when you need a `StatementHandle` instead of waiting through
+`execute()`:
+
+```ts
+const handle = await client.statement("SELECT 1 AS ok").submit();
+
+console.log(handle.status());
+await handle.fetchOnce();
+const result = await handle.fetch();
+```
+
+An `AbortSignal` stops client-side requests and polling; it does not cancel a
+statement in ScopeDB. Call `handle.cancel()` to request server-side
+cancellation. See the [HTTP API](/developer/http-api) for the underlying state
+and cancellation contract.
+
+## Ingest data
+
+The current SDK exposes `ingestStream()` for batching JSON rows that share one
+ScopeQL transformation. Follow [Ingest data](/guides/ingest-events) for the
+current write workflow. Reuse a stream for its transformation and always call
+`shutdown()` when finished; `shutdown()` flushes remaining rows, so a preceding
+`flush()` is optional.
+
+The helper retries transient failures. A lost response can cause a row to be
+sent again, so use the retry guidance in the
+[HTTP API](/developer/http-api#errors-and-retries).
+
+## Next steps
+
+- Build application queries with [Query data](/guides/query-events).
+- Review statement states, errors, and retries in the
+  [HTTP API](/developer/http-api).
+- Browse the [Node.js SDK repository](https://github.com/scopedb/scopedb-js)
+  for the complete package surface.

--- a/src/content/developer/sdks.mdx
+++ b/src/content/developer/sdks.mdx
@@ -1,0 +1,40 @@
+---
+title: SDKs
+relatedContents:
+    - title: Connect an application
+      url: /guides/connect-to-scopedb
+    - title: HTTP API
+      url: /developer/http-api
+    - title: Query data
+      url: /guides/query-events
+---
+
+Use a ScopeDB SDK from a supported backend runtime. SDKs configure
+authentication, follow statement execution to a terminal result, and convert
+result cells into language-native values.
+
+These SDKs are pre-release. The pages below describe current behavior only;
+pin your dependency version and upgrade intentionally.
+
+## Choose an SDK
+
+| Runtime | Package | Start here |
+| --- | --- | --- |
+| Node.js 20 or later | [`scopedb`](https://www.npmjs.com/package/scopedb) | [Node.js SDK](/developer/nodejs) |
+| Go 1.24 or later | [`github.com/scopedb/scopedb-sdk/go`](https://pkg.go.dev/github.com/scopedb/scopedb-sdk/go) | [Go SDK](/developer/go) |
+
+Use the [HTTP API](/developer/http-api) from other backend runtimes or when you
+need direct control over requests and responses.
+
+## Common workflow
+
+1. Copy the ScopeDB API address and create an API key by following
+   [Connect an application](/guides/connect-to-scopedb).
+2. Create a client in a trusted server-side process.
+3. Execute a ScopeQL statement. The SDK consumes a terminal submit response or
+   polls while the statement is `pending` or `running`.
+4. Convert the result into the representation expected by your application.
+
+Each language page covers its result types, client-side cancellation, and
+lower-level statement controls. For the underlying statement lifecycle, error
+contract, and retry guidance, use the [HTTP API](/developer/http-api).

--- a/src/content/guides/connect-to-scopedb.mdx
+++ b/src/content/guides/connect-to-scopedb.mdx
@@ -7,8 +7,8 @@ relatedContents:
       url: /guides/authentication
     - title: HTTP API
       url: /developer/http-api
-    - title: Node.js SDK
-      url: /developer/nodejs
+    - title: SDKs
+      url: /developer/sdks
 ---
 
 Connect a client to your workspace with two values from ScopeDB Console:
@@ -86,6 +86,6 @@ described in the [HTTP API guide](/developer/http-api#poll-a-statement).
 ## Use the connection
 
 The **Connect** page also provides copy-ready recipes for supported clients. For
-the full behavior of each interface, see the [HTTP API](/developer/http-api),
-[Node.js SDK](/developer/nodejs), [Go SDK](/developer/go), or
+the full behavior of each interface, choose an [SDK](/developer/sdks), use the
+[HTTP API](/developer/http-api), or continue with the
 [ScopeQL CLI](/developer/scopeql-cli).

--- a/src/sidebars.ts
+++ b/src/sidebars.ts
@@ -31,21 +31,14 @@ export const guidesSidebar: SidebarItem[] = [
 export const developerSidebar: SidebarItem[] = [
     { label: "Overview", link: "/developer" },
     {
-        label: "APIs", items: [
-            { label: "HTTP API", link: "/developer/http-api" },
-        ],
-    },
-    {
         label: "SDKs", items: [
+            { label: "Overview", link: "/developer/sdks" },
             { label: "Node.js SDK", link: "/developer/nodejs" },
             { label: "Go SDK", link: "/developer/go" },
         ],
     },
-    {
-        label: "Tools", items: [
-            { label: "ScopeQL CLI", link: "/developer/scopeql-cli" },
-        ],
-    },
+    { label: "HTTP API", link: "/developer/http-api" },
+    { label: "ScopeQL CLI", link: "/developer/scopeql-cli" },
 ];
 
 export const referenceSidebar: SidebarItem[] = [


### PR DESCRIPTION
## What

- Add an SDK overview that routes developers to Node.js, Go, or the HTTP API.
- Give the Node.js and Go guides one task-oriented structure: install, connect, execute, convert results, control execution, and next steps.
- Keep language-specific result and cancellation behavior while moving raw protocol details to the HTTP API.
- Reduce legacy ingest coverage to the minimum needed before Table Append becomes the recommended write path.
- Align the Developer sidebar and Connect guide with the new SDK entry point.

## Why

The SDK pages were isolated and structurally inconsistent. This made it harder to choose an SDK, compare language behavior, and distinguish SDK responsibilities from the underlying HTTP contract.

## Impact

This is documentation-only. It documents current pre-release SDK behavior and does not add deployment, internal topology, or low-level transport details.

The Go binary and fixed-duration interval conversions require a release that includes scopedb/scopedb-sdk#105 before this documentation is published.

## Checks

- pnpm build
- git diff --check
- Local route checks for /developer, /developer/sdks, /developer/nodejs, /developer/go, and /sitemap.xml