### PR TITLE
docs: document SDK result value mappings

### DIFF
--- a/src/content/developer/go.mdx
+++ b/src/content/developer/go.mdx
@@ -72,15 +72,40 @@ if err != nil {
 fmt.Println(rows)
 ```
 
-The current conversions are:
+### Result value mapping
 
-| ScopeDB value | Go value |
-| --- | --- |
-| `binary` | `[]byte` |
-| `timestamp` | `time.Time` |
-| Fixed-duration `interval` | `time.Duration` |
-| `null` | `nil` |
-| `array`, `object`, or `any` | JSON string |
+`ToValues` converts each non-null result cell according to its ScopeDB result
+type:
+
+| ScopeDB result type | Go value | Notes |
+| --- | --- | --- |
+| `int` | `int64` | |
+| `uint` | `uint64` | |
+| `float` | `float64` | Includes `NaN` and infinities. |
+| `binary` | `[]byte` | Decoded bytes. |
+| `string` | `string` | |
+| `boolean` | `bool` | |
+| `timestamp` | `time.Time` | Preserves nanosecond precision. |
+| `interval` | `time.Duration` | Fixed-duration intervals only. |
+| `array` | `string` | JSON text; decode with `encoding/json` when needed. |
+| `object` | `string` | JSON text; decode with `encoding/json` when needed. |
+| `any` | `string` | Raw textual value; the SDK does not infer its dynamic Go type. |
+| `null` | `nil` | A null cell is `nil` regardless of the field's declared type. |
+
+The `null` result type can appear in query metadata, such as for a literal
+`NULL`; it is not a table column type. See the
+[data types reference](/reference/data-types) for ScopeDB type semantics.
+
+`ToValues` returns an error when a non-null cell cannot be converted, a numeric
+value is out of range, or the result contains an unrecognized data type.
+
+`array` and `object` contain JSON text, but do not assume that an `any` value is
+JSON. It remains raw text because its dynamic ScopeDB type cannot be
+reconstructed from the result. Decode structured values into a concrete Go
+type, or use `json.Decoder.UseNumber` when decoding into interface values and
+numeric precision matters. Decoding structured values does not recursively
+apply the SDK's result conversions; nested binary, timestamp, and interval
+values remain strings.
 
 ## Control statement execution
 

--- a/src/content/developer/nodejs.mdx
+++ b/src/content/developer/nodejs.mdx
@@ -78,6 +78,30 @@ console.log(rows[0]);
 Use `first()` for a lookup or aggregate that returns at most one row, and
 `intoValues()` when positional arrays are more convenient.
 
+### Result value mapping
+
+`intoValues()`, `intoObjects()`, and `first()` convert result cells according
+to their ScopeDB result type:
+
+| ScopeDB result type | JavaScript value | Notes |
+| --- | --- | --- |
+| `int` | `bigint` | Use `integerMode` to return a `number` or decimal `string` instead. |
+| `uint` | `bigint` | Use `integerMode` to return a `number` or decimal `string` instead. |
+| `float` | `number` | Finite values only; `NaN` and infinities cause conversion to throw. |
+| `binary` | `string` | Hexadecimal representation. |
+| `string` | `string` | |
+| `boolean` | `boolean` | |
+| `timestamp` | `Date` | JavaScript `Date` preserves milliseconds, not nanoseconds. |
+| `interval` | `string` | Fixed-duration ISO 8601 representation. |
+| `array` | `string` | JSON text; use `JSON.parse()` when an array is needed. |
+| `object` | `string` | JSON text; use `JSON.parse()` when an object is needed. |
+| `any` | `string` | Raw textual value; the SDK does not infer its dynamic JavaScript type. |
+| `null` | `null` | A null cell is `null` regardless of the field's declared type. |
+
+The `null` result type can appear in query metadata, such as for a literal
+`NULL`; it is not a table column type. See the
+[data types reference](/reference/data-types) for ScopeDB type semantics.
+
 ScopeDB integers can exceed JavaScript's safe integer range. The SDK returns
 them as `bigint` by default, which preserves precision but cannot be passed to
 `JSON.stringify` directly. Choose the representation at the application
@@ -92,6 +116,17 @@ Use:
 - `bigint` for lossless JavaScript arithmetic;
 - `string` for JSON-safe identifiers or unbounded counters;
 - `number` only when values fit within JavaScript's safe integer range.
+
+Converting a `timestamp` to `Date` discards sub-millisecond precision. Use
+`jsonRows()` when the application must retain the original result text.
+
+`array` and `object` values contain JSON text. Do not assume that an `any`
+value is JSON: it remains raw text because its dynamic ScopeDB type cannot be
+reconstructed from the result. When parsing `array` or `object` values with
+`JSON.parse()`, nested integers outside JavaScript's safe range can lose
+precision. Parsing structured values does not recursively apply the SDK's
+result conversions; nested binary, timestamp, and interval values remain
+strings.
 
 ## Control statement execution
 


### PR DESCRIPTION
## What changed

- add complete 12-type result mappings to the Node.js SDK guide
- replace the partial Go mapping with a complete conversion table
- document integer and timestamp precision, structured-value decoding, `any` raw text, and result-only `null`
- keep the pages focused on user-observable SDK behavior rather than internal result encoding

## Why

The SDK overview says each language guide covers result types, but the Node.js page previously covered only integer modes and the Go page covered only selected special types. This made it difficult for users to predict the value returned by each SDK.

## Validation

- `git diff --check`
- `pnpm build`

## Release coordination

The Go table follows the latest pre-release SDK behavior on `main`, including scopedb/scopedb-sdk#105. The current `go/v0.5.0` tag predates those conversions, so this documentation should be coordinated with the next Go SDK tag.