### PR TITLE
docs: add data retention guide

### DIFF
--- a/src/content/guides/data-retention.mdx
+++ b/src/content/guides/data-retention.mdx
@@ -1,0 +1,83 @@
+---
+title: Set data retention
+relatedContents:
+    - title: CREATE TABLE
+      url: /reference/commands/statements/create-table
+    - title: ALTER TABLE
+      url: /reference/commands/statements/alter-table
+    - title: Query data
+      url: /guides/query-events
+---
+
+Use a table-level retention policy to make stored data eligible for asynchronous
+expiration after a configured window. ScopeDB accepts a whole number from 1
+through 1825 days. Tables have no automatic retention policy unless you
+configure one.
+
+Retention is a table lifecycle policy, not a row-level time-to-live rule. It
+does not use a timestamp column from your data to decide when an individual row
+expires. Because enforcement is asynchronous, eligible data may remain
+queryable for some time.
+
+## Set retention when you create a table
+
+Add `DATA RETENTION <days> DAY` to `CREATE TABLE`. Use `DAY` even when the value
+is greater than one:
+
+```scopeql
+CREATE TABLE events (
+    time timestamp,
+    service string,
+    name string,
+    message string,
+    var object
+)
+DATA RETENTION 30 DAY;
+```
+
+## Change retention for an existing table
+
+Use `ALTER TABLE` to change the retention window:
+
+```scopeql
+ALTER TABLE events SET DATA RETENTION 90 DAY;
+```
+
+Changes apply to subsequent cleanup. Reducing the window can make existing data
+eligible for removal. The policy applies to the entire table, including data
+that existed before you changed it. Increasing the window does not restore data
+that ScopeDB has already removed.
+
+## Check the current policy
+
+Query `system.tables` to inspect the retention setting:
+
+```scopeql
+FROM system.tables
+SELECT database_name, schema_name, table_name, data_retention_days
+WHERE database_name = 'scopedb'
+  AND schema_name = 'public'
+ORDER BY table_name;
+```
+
+`data_retention_days` is `NULL` when the table has no automatic retention
+policy.
+
+## Remove a retention policy
+
+To stop automatic retention cleanup for a table:
+
+```scopeql
+ALTER TABLE events DROP DATA RETENTION;
+```
+
+Removing the policy prevents future retention enforcement. It cannot recover
+data that ScopeDB already expired while the policy was active.
+
+## Choose a retention window
+
+Use a window that matches how long the table remains useful and any retention
+requirements that apply to the data. If datasets need different windows, keep
+them in separate tables so each table can have its own policy.
+
+Use `DELETE` when you need to target specific rows.

--- a/src/content/guides/index.mdx
+++ b/src/content/guides/index.mdx
@@ -40,6 +40,11 @@ and join metadata.
 Decide what belongs in typed columns and what belongs in a semi-structured
 `object` column.
 
+### [Set data retention](/guides/data-retention)
+
+Make table data eligible for asynchronous expiration after a configurable
+retention window.
+
 ### [Add indexes](/guides/add-indexes)
 
 Choose point, range, search, and materialized indexes from real query patterns.
@@ -63,6 +68,7 @@ Then choose the guide for the task in front of you:
 - write data producers with [Ingest data](/guides/ingest-events);
 - inspect and aggregate data with [Query data](/guides/query-events);
 - design flexible schemas with [Model semi-structured data](/guides/model-flexible-events);
+- remove data you no longer need with [Data retention](/guides/data-retention);
 - improve important query paths with [Add indexes](/guides/add-indexes).
 
 For exact syntax, use the [Reference](/reference).

--- a/src/content/reference/commands/statements/alter-table.mdx
+++ b/src/content/reference/commands/statements/alter-table.mdx
@@ -1,5 +1,8 @@
 ---
 title: ALTER TABLE
+relatedContents:
+    - title: Set data retention
+      url: /guides/data-retention
 ---
 
 Modifies an existing table in the system.
@@ -33,4 +36,25 @@ ALTER TABLE [ IF EXISTS ] <table_name>
 
 ALTER TABLE [ IF EXISTS ] <table_name>
   DROP CLUSTER KEY
+
+ALTER TABLE [ IF EXISTS ] <table_name>
+  SET DATA RETENTION <days> DAY
+
+ALTER TABLE [ IF EXISTS ] <table_name>
+  DROP DATA RETENTION
 ```
+
+## Data retention
+
+`SET DATA RETENTION` configures a table-level retention window. `<days>` must
+be a whole number from 1 through 1825. `DROP DATA RETENTION` removes the policy
+without restoring data that has already been removed.
+
+```scopeql
+ALTER TABLE events SET DATA RETENTION 90 DAY;
+
+ALTER TABLE events DROP DATA RETENTION;
+```
+
+See [Set data retention](/guides/data-retention) for lifecycle behavior and how
+to inspect the current policy.

--- a/src/content/reference/commands/statements/create-table.mdx
+++ b/src/content/reference/commands/statements/create-table.mdx
@@ -1,5 +1,8 @@
 ---
 title: CREATE TABLE
+relatedContents:
+    - title: Set data retention
+      url: /guides/data-retention
 ---
 
 Creates a new table in the system.
@@ -15,6 +18,7 @@ CREATE TABLE [ IF NOT EXISTS ] <table_name> (
 [ PARTITION BY <expr> [, ...] ]
 [ CLUSTER BY <expr> [, ...] ]
 [ DISTINCT ON <expr> [, ...] [ BY <order_by_expr> [, ...] ] ]
+[ DATA RETENTION <days> DAY ]
 [ COMMENT = '<string_literal>' ]
 ```
 
@@ -35,6 +39,15 @@ Defines the table cluster key. ScopeDB uses the cluster key to keep related rows
 Use `CLUSTER BY` for fields that are commonly used in filters, range predicates, or ordered access within a partition. For example, an events table partitioned by hourly time buckets might cluster by `account_id`, `event_type`, or `ts` depending on the most common query pattern.
 
 Cluster expressions must be deterministic and must not be constant. `CLUSTER BY` can be used together with `PARTITION BY`; partitioning chooses the broad data grouping, while clustering improves locality inside each group.
+
+### `DATA RETENTION <days> DAY`
+
+Configures automatic table-level data retention. `<days>` must be a whole
+number from 1 through 1825. If this clause is omitted, the table has no
+automatic retention policy.
+
+See [Set data retention](/guides/data-retention) for lifecycle behavior and how
+to inspect or change the policy.
 
 ## Examples
 
@@ -65,5 +78,6 @@ CREATE TABLE latest_logs (
     ts timestamp,
     message string
 )
-DISTINCT ON host BY ts DESC NULLS LAST;
+DISTINCT ON host BY ts DESC NULLS LAST
+DATA RETENTION 30 DAY;
 ```

--- a/src/sidebars.ts
+++ b/src/sidebars.ts
@@ -18,6 +18,7 @@ export const guidesSidebar: SidebarItem[] = [
             { label: "Ingest data", link: "/guides/ingest-events" },
             { label: "Query data", link: "/guides/query-events" },
             { label: "Model semi-structured data", link: "/guides/model-flexible-events" },
+            { label: "Set data retention", link: "/guides/data-retention" },
             { label: "Add indexes", link: "/guides/add-indexes" },
         ],
     },


### PR DESCRIPTION
## Summary

- add a task-oriented guide for configuring, changing, inspecting, and removing table data retention
- document the `DATA RETENTION` clauses in the `CREATE TABLE` and `ALTER TABLE` references
- add the guide to the Work with data navigation

## Why

Data retention is available in ScopeDB but was not represented in the public documentation. This documents the SaaS-facing contract—table scope, the 1–1825 day range, asynchronous enforcement, and non-row-level semantics—without exposing deployment or storage implementation details.

## Validation

- `pnpm build`
- `git diff --check`