### PR TITLE
docs: improve ScopeQL knowledge discovery

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,28 @@
+# ScopeDB documentation
+
+> Canonical public documentation for ScopeDB and the ScopeQL language. SDK
+> documentation describes client behavior; use the ScopeQL guides and reference
+> for language syntax.
+
+## Learn ScopeQL
+
+- [Quickstart](https://docs.scopedb.io/guides/quickstart): Create a table and run initial ScopeQL queries.
+- [Query data](https://docs.scopedb.io/guides/query-events): Common filtering, projection, aggregation, ordering, and join workflows.
+- [ScopeQL reference](https://docs.scopedb.io/reference/): Language syntax, data types, statements, operators, and functions.
+- [Query syntax](https://docs.scopedb.io/reference/commands/stmt-query): Canonical query pipeline syntax.
+- [Statements](https://docs.scopedb.io/reference/commands/statements): DDL and DML statements.
+- [Functions](https://docs.scopedb.io/reference/functions): Scalar and aggregate functions.
+
+## Build with ScopeDB
+
+- [Connect an application](https://docs.scopedb.io/guides/connect-to-scopedb): Configure an endpoint and API key.
+- [SDK overview](https://docs.scopedb.io/developer/sdks): Choose a supported SDK.
+- [Node.js SDK](https://docs.scopedb.io/developer/nodejs): Use the JavaScript and TypeScript client.
+- [Go SDK](https://docs.scopedb.io/developer/go): Use the Go client.
+- [Rust SDK](https://docs.scopedb.io/developer/rust): Use the async Rust client.
+- [HTTP API](https://docs.scopedb.io/developer/http-api): Request, response, statement lifecycle, and error contracts.
+- [ScopeQL CLI](https://docs.scopedb.io/developer/scopeql-cli): Run ScopeQL from a terminal, script, or CI job.
+
+## Discovery
+
+- [Sitemap](https://docs.scopedb.io/sitemap.xml): Complete documentation URL index.

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://docs.scopedb.io/sitemap.xml",
+  };
+}

--- a/src/content/developer/go.mdx
+++ b/src/content/developer/go.mdx
@@ -120,7 +120,9 @@ underlying state and cancellation contract.
 
 ## Next steps
 
+- Learn the language with the [ScopeQL quickstart](/guides/quickstart).
 - Build application queries with [Query data](/guides/query-events).
+- Use the [ScopeQL reference](/reference) for exact language syntax.
 - Follow [Ingest data](/guides/ingest-events) for the current write workflow.
 - Review statement states, errors, and retries in the
   [HTTP API](/developer/http-api).

--- a/src/content/developer/index.mdx
+++ b/src/content/developer/index.mdx
@@ -18,7 +18,7 @@ request.
 
 ### [SDKs](/developer/sdks)
 
-Build backend applications with the Node.js or Go SDK. Start with the SDK
+Build backend applications with the Node.js, Go, or Rust SDK. Start with the SDK
 overview, then follow the task-based guide for your language.
 
 ### [HTTP API](/developer/http-api)

--- a/src/content/developer/nodejs.mdx
+++ b/src/content/developer/nodejs.mdx
@@ -160,7 +160,9 @@ sent again, so use the retry guidance in the
 
 ## Next steps
 
+- Learn the language with the [ScopeQL quickstart](/guides/quickstart).
 - Build application queries with [Query data](/guides/query-events).
+- Use the [ScopeQL reference](/reference) for exact language syntax.
 - Review statement states, errors, and retries in the
   [HTTP API](/developer/http-api).
 - Browse the [Node.js SDK repository](https://github.com/scopedb/scopedb-js)

--- a/src/content/developer/rust.mdx
+++ b/src/content/developer/rust.mdx
@@ -1,0 +1,172 @@
+---
+title: Rust SDK
+relatedContents:
+    - title: SDKs
+      url: /developer/sdks
+    - title: Connect an application
+      url: /guides/connect-to-scopedb
+    - title: Query data
+      url: /guides/query-events
+    - title: Rust SDK repository
+      url: https://github.com/scopedb/scopedb-sdk/tree/main/rust
+---
+
+Use the async Rust SDK from trusted backend applications and services.
+
+## Before you start
+
+Use Rust 1.85 or later. Follow
+[Connect an application](/guides/connect-to-scopedb), then set the endpoint and
+API key used by the examples:
+
+```bash
+export SCOPEDB_ENDPOINT="https://<endpoint>"
+export SCOPEDB_API_KEY="<api-key>"
+```
+
+## Install
+
+```bash
+cargo add scopedb-client serde_json
+cargo add tokio --features macros,rt-multi-thread
+```
+
+## Create a client
+
+The SDK accepts a configured HTTP client. Use the compatible `reqwest` version
+re-exported by `scopedb-client` to configure authentication, TLS, timeouts, and
+connection pooling:
+
+```rust
+use scopedb_client::Client;
+use scopedb_client::reqwest;
+use scopedb_client::reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+
+let endpoint = std::env::var("SCOPEDB_ENDPOINT")?;
+let api_key = std::env::var("SCOPEDB_API_KEY")?;
+
+let mut authorization = HeaderValue::from_str(&format!("Bearer {api_key}"))?;
+authorization.set_sensitive(true);
+
+let mut headers = HeaderMap::new();
+headers.insert(AUTHORIZATION, authorization);
+
+let http_client = reqwest::Client::builder()
+    .default_headers(headers)
+    .build()?;
+let client = Client::new(endpoint, http_client)?;
+```
+
+Marking the authorization header as sensitive prevents standard header and
+request `Debug` formatting from exposing the API key.
+
+## Execute a statement
+
+```rust
+let result = client
+    .statement(
+        r#"
+        FROM events
+        WHERE service = 'checkout'
+        ORDER BY time DESC
+        LIMIT 10
+        "#
+        .to_string(),
+    )
+    .execute()
+    .await?;
+```
+
+`execute()` waits for a terminal result and returns an error when execution
+fails or is cancelled.
+
+## Work with results
+
+Convert result cells to typed Rust values:
+
+```rust
+let fields = result.schema().fields();
+println!("{} columns", fields.len());
+
+let rows = result.into_values()?;
+println!("{rows:?}");
+```
+
+Use `json_rows()` when the application needs unconverted string cell values
+instead of typed SDK values. See the
+[data types reference](/reference/data-types) for ScopeDB type semantics.
+
+## Control statement execution
+
+Use `submit()` when you need a statement handle instead of waiting through
+`execute()`:
+
+```rust
+let mut handle = client.statement("SELECT 1 AS ok".to_string()).submit().await?;
+
+println!("status: {:?}", handle.status());
+handle.fetch_once().await?;
+let result = handle.fetch().await?;
+```
+
+Dropping the future stops client-side waiting; it does not cancel the remote
+statement. Call `handle.cancel().await` to request server-side cancellation.
+See the [HTTP API](/developer/http-api) for the underlying lifecycle and error
+contract.
+
+## Browse the catalog
+
+List methods return one page and preserve the opaque continuation token. Fetch
+methods return a complete database, schema, or table resource:
+
+```rust
+use scopedb_client::CatalogListOptions;
+
+let tables = client
+    .list_tables("scopedb", "public", CatalogListOptions::default())
+    .await?;
+let table = client.fetch_table("scopedb", "public", "events").await?;
+
+println!("{} tables; selected {}", tables.items.len(), table.name);
+```
+
+## Stream JSON rows to a table
+
+Use `append_stream()` when records already match an existing destination table.
+It serializes each object as NDJSON, creates bounded batches, and limits
+concurrent append requests:
+
+```rust
+use std::time::Duration;
+
+let stream = client
+    .table("events")
+    .with_schema("public")
+    .append_stream()
+    .batch_bytes(4 * 1024 * 1024)
+    .flush_interval(Duration::from_secs(1))
+    .max_in_flight_requests(4)
+    .build()?;
+
+stream
+    .send(&serde_json::json!({
+        "service": "checkout",
+        "name": "request.completed",
+    }))
+    .await?;
+
+let report = stream.shutdown().await?;
+println!("committed {} rows", report.committed_rows);
+```
+
+`send()` confirms local admission, not remote commit. `flush()` and `shutdown()`
+are remote delivery barriers. The in-memory stream is not a durable queue; use
+an outbox when rows must survive process failure.
+
+## Next steps
+
+- Learn the language with the [ScopeQL quickstart](/guides/quickstart).
+- Build application queries with [Query data](/guides/query-events).
+- Use the [ScopeQL reference](/reference) for exact language syntax.
+- Review the [Rust SDK examples](https://github.com/scopedb/scopedb-sdk/tree/main/rust/examples)
+  for catalog, direct append, streaming write, and telemetry workflows.

--- a/src/content/developer/scopeql-cli.mdx
+++ b/src/content/developer/scopeql-cli.mdx
@@ -5,12 +5,18 @@ relatedContents:
       url: /guides/connect-to-scopedb
     - title: Authentication and API keys
       url: /guides/authentication
+    - title: ScopeQL quickstart
+      url: /guides/quickstart
+    - title: ScopeQL reference
+      url: /reference
     - title: ScopeQL repository
       url: https://github.com/scopedb/scopeql
 ---
 
 Use the ScopeQL CLI to work with a ScopeDB workspace from a terminal, script,
-or CI job.
+or CI job. This page documents the CLI; use the [ScopeQL quickstart](/guides/quickstart)
+for a guided introduction and the [Reference](/reference) for exact language
+syntax.
 
 ## Before you start
 

--- a/src/content/developer/sdks.mdx
+++ b/src/content/developer/sdks.mdx
@@ -22,6 +22,7 @@ pin your dependency version and upgrade intentionally.
 | --- | --- | --- |
 | Node.js 20 or later | [`scopedb`](https://www.npmjs.com/package/scopedb) | [Node.js SDK](/developer/nodejs) |
 | Go 1.24 or later | [`github.com/scopedb/scopedb-sdk/go`](https://pkg.go.dev/github.com/scopedb/scopedb-sdk/go) | [Go SDK](/developer/go) |
+| Rust 1.85 or later | [`scopedb-client`](https://crates.io/crates/scopedb-client) | [Rust SDK](/developer/rust) |
 
 Use the [HTTP API](/developer/http-api) from other backend runtimes or when you
 need direct control over requests and responses.
@@ -38,3 +39,7 @@ need direct control over requests and responses.
 Each language page covers its result types, client-side cancellation, and
 lower-level statement controls. For the underlying statement lifecycle, error
 contract, and retry guidance, use the [HTTP API](/developer/http-api).
+
+SDK documentation covers client behavior, not the ScopeQL language. Start with
+the [ScopeQL quickstart](/guides/quickstart), use [Query data](/guides/query-events)
+for common query workflows, and use the [Reference](/reference) for exact syntax.

--- a/src/content/reference/functions/aggregate/count.mdx
+++ b/src/content/reference/functions/aggregate/count.mdx
@@ -2,20 +2,37 @@
 title: count
 ---
 
-Returns the number of records with non-NULL values for the specified field. If all records are NULL, the function returns 0.
+Returns either the number of input records or the number of records for which
+an expression is non-NULL.
 
 ## Syntax
 
 ```scopeql
-count( <expr> )
+count()
+count(<expr>)
 ```
 
 ## Arguments
 
 ### `<expr>`
 
-A column name, which can be a qualified name (for example, database.schema.table.column_name).
+An expression to evaluate for each input record. `count(<expr>)` counts only
+records for which the expression evaluates to a non-NULL value. If every value
+is NULL, it returns 0.
+
+Omit the argument to count every input record, including records whose fields
+are all NULL. Use `count()` for this form; SQL-style `count(*)` is not ScopeQL
+syntax.
 
 ## Returns
 
 Returns a value of type int.
+
+## Example
+
+Count all events and the events that have a user identifier:
+
+```scopeql
+FROM events
+AGGREGATE count() AS events, count(user_id) AS identified_events
+```

--- a/src/sidebars.ts
+++ b/src/sidebars.ts
@@ -36,6 +36,7 @@ export const developerSidebar: SidebarItem[] = [
             { label: "Overview", link: "/developer/sdks" },
             { label: "Node.js SDK", link: "/developer/nodejs" },
             { label: "Go SDK", link: "/developer/go" },
+            { label: "Rust SDK", link: "/developer/rust" },
         ],
     },
     { label: "HTTP API", link: "/developer/http-api" },


### PR DESCRIPTION
## Summary

- add a Rust SDK guide and include Rust in the developer navigation and SDK overview
- add direct ScopeQL quickstart and reference handoffs across SDK and CLI pages
- document both `count()` and `count(expr)`, including that SQL-style `count(*)` is not ScopeQL syntax
- publish `/llms.txt` as a compact canonical index for agents
- publish `/robots.txt` with the documentation sitemap

## Why

The language reference was complete once discovered, but public SDK and CLI entry points did not provide a consistent route to it. The developer docs also omitted Rust, the `count` reference omitted the row-count form used by the guides, and the site had no conventional agent index.

## Impact

Human and agent consumers now get the same explicit knowledge path: SDK or CLI documentation for interface behavior, and Quickstart, Query data, or Reference for ScopeQL syntax.

## Validation

- `pnpm build`
- OpenNext Cloudflare production build
- verified local 200 responses for `/llms.txt`, `/robots.txt`, `/developer/rust`, and the updated count page
- verified the sitemap includes the Rust SDK page
- read-only live query confirmed `count()` counts all rows and `count(expr)` counts non-NULL values
- fresh discovery audit confirmed the README, CLI, docs, llms, robots, and sitemap paths are closed
- independent review found no remaining issues
- `git diff --check`