### PR TITLE
docs: improve site SEO metadata

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,13 @@ import scopeql from "./shiki-scopeql-grammar.json"
 
 const nextConfig: NextConfig = {
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
+  async redirects() {
+    return [
+      { source: '/guides/index', destination: '/guides', permanent: true },
+      { source: '/developer/index', destination: '/developer', permanent: true },
+      { source: '/reference/index', destination: '/reference', permanent: true },
+    ]
+  },
 };
 
 const withMDX = createMDX({

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,14 +1,14 @@
 # ScopeDB documentation
 
-> Canonical public documentation for ScopeDB and the ScopeQL language. SDK
-> documentation describes client behavior; use the ScopeQL guides and reference
-> for language syntax.
+> Canonical public documentation for ScopeDB Cloud, the serverless database for
+> event analytics, and the ScopeQL language. SDK documentation describes client
+> behavior; use the ScopeQL guides and reference for language syntax.
 
 ## Learn ScopeQL
 
 - [Quickstart](https://docs.scopedb.io/guides/quickstart): Create a table and run initial ScopeQL queries.
 - [Query data](https://docs.scopedb.io/guides/query-events): Common filtering, projection, aggregation, ordering, and join workflows.
-- [ScopeQL reference](https://docs.scopedb.io/reference/): Language syntax, data types, statements, operators, and functions.
+- [ScopeQL reference](https://docs.scopedb.io/reference): Language syntax, data types, statements, operators, and functions.
 - [Query syntax](https://docs.scopedb.io/reference/commands/stmt-query): Canonical query pipeline syntax.
 - [Statements](https://docs.scopedb.io/reference/commands/statements): DDL and DML statements.
 - [Functions](https://docs.scopedb.io/reference/functions): Scalar and aggregate functions.

--- a/src/app/developer/[[...slug]]/page.tsx
+++ b/src/app/developer/[[...slug]]/page.tsx
@@ -1,22 +1,34 @@
 import { loadContent } from "@/utils/loader";
 import { loadContentMetadata } from "@/utils/metadata";
+import { getContentPath } from "@/utils/seo";
 import Document from "@/components/Document";
+import { permanentRedirect } from "next/navigation";
 
 export async function generateMetadata({ params }: {
-    params: Promise<{ slug: string }>
-}): Promise<{ title: string }> {
+    params: Promise<{ slug?: string[] }>
+}) {
     const { slug } = await params
     return await loadContentMetadata("developer", slug, { title: "Developer" })
 }
 
 export default async function Developer({ params }: {
-    params: Promise<{ slug: string }>
+    params: Promise<{ slug?: string[] }>
 }) {
     const { slug } = await params
+    if (slug?.at(-1) === "index") {
+        permanentRedirect(getContentPath("developer", slug))
+    }
+
     const { Content, frontmatter, headings } = await loadContent("developer", slug)
     return (
-        <Document headings={headings} relatedContents={frontmatter.relatedContents}>
-            <h1>{frontmatter.title}</h1>
+        <Document
+            headings={headings}
+            relatedContents={frontmatter.relatedContents}
+            title={frontmatter.title}
+            description={frontmatter.description}
+            category="developer"
+            slug={slug}
+        >
             <Content />
         </Document>
     );

--- a/src/app/guides/[[...slug]]/page.tsx
+++ b/src/app/guides/[[...slug]]/page.tsx
@@ -1,22 +1,34 @@
 import { loadContent } from "@/utils/loader";
 import { loadContentMetadata } from "@/utils/metadata";
+import { getContentPath } from "@/utils/seo";
 import Document from "@/components/Document";
+import { permanentRedirect } from "next/navigation";
 
 export async function generateMetadata({ params }: {
-    params: Promise<{ slug: string }>
-}): Promise<{ title: string }> {
+    params: Promise<{ slug?: string[] }>
+}) {
     const { slug } = await params
     return await loadContentMetadata("guides", slug, { title: "Guides" })
 }
 
 export default async function Guides({ params }: {
-    params: Promise<{ slug: string }>
+    params: Promise<{ slug?: string[] }>
 }) {
     const { slug } = await params
+    if (slug?.at(-1) === "index") {
+        permanentRedirect(getContentPath("guides", slug))
+    }
+
     const { Content, frontmatter, headings } = await loadContent("guides", slug)
     return (
-        <Document headings={headings} relatedContents={frontmatter.relatedContents}>
-            <h1>{frontmatter.title}</h1>
+        <Document
+            headings={headings}
+            relatedContents={frontmatter.relatedContents}
+            title={frontmatter.title}
+            description={frontmatter.description}
+            category="guides"
+            slug={slug}
+        >
             <Content />
         </Document>
     );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import { AntdRegistry } from '@ant-design/nextjs-registry';
 import { Inter, Roboto_Mono } from "next/font/google";
+import type { Metadata } from "next";
 import Header from "@/components/Header";
+import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/utils/seo";
 import "./globals.css";
 
 const inter = Inter({
@@ -14,6 +16,41 @@ const robotoMono = Roboto_Mono({
   subsets: ["latin"],
 });
 
+export const metadata: Metadata = {
+  metadataBase: SITE_URL,
+  title: {
+    default: SITE_NAME,
+    template: `%s | ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  applicationName: SITE_NAME,
+  icons: {
+    icon: "/favicon.svg",
+  },
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    siteName: SITE_NAME,
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    url: "/",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "ScopeDB Docs — serverless database for event analytics",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: SITE_NAME,
+    description: SITE_DESCRIPTION,
+    images: ["/opengraph-image"],
+  },
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -26,9 +63,6 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <head>
-        <meta charSet="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <script async defer data-domain="docs.scopedb.io" src="https://plausible.io/js/script.js" />
       </head>
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,59 @@
+import { ImageResponse } from "next/og";
+
+export const alt = "ScopeDB Docs — serverless database for event analytics";
+export const size = {
+    width: 1200,
+    height: 630,
+};
+export const contentType = "image/png";
+
+export default function Image() {
+    return new ImageResponse(
+        (
+            <div
+                style={{
+                    alignItems: "flex-start",
+                    background: "linear-gradient(135deg, #ffffff 0%, #eef7ff 100%)",
+                    color: "#111827",
+                    display: "flex",
+                    flexDirection: "column",
+                    height: "100%",
+                    justifyContent: "space-between",
+                    padding: "72px 80px",
+                    width: "100%",
+                }}
+            >
+                <div
+                    style={{
+                        alignItems: "center",
+                        color: "#0879e0",
+                        display: "flex",
+                        fontSize: 34,
+                        fontWeight: 700,
+                        letterSpacing: "-0.02em",
+                    }}
+                >
+                    ScopeDB Docs
+                </div>
+                <div style={{ display: "flex", flexDirection: "column", gap: 22 }}>
+                    <div
+                        style={{
+                            display: "flex",
+                            fontSize: 64,
+                            fontWeight: 650,
+                            letterSpacing: "-0.045em",
+                            lineHeight: 1.05,
+                            maxWidth: 1000,
+                        }}
+                    >
+                        Serverless database for event analytics
+                    </div>
+                    <div style={{ color: "#52606d", display: "flex", fontSize: 27 }}>
+                        ScopeQL · SDKs · APIs · Guides
+                    </div>
+                </div>
+            </div>
+        ),
+        size,
+    );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -105,13 +105,12 @@ export default function Home() {
         }}
       />
       <div className="py-[16px] px-[12px] md:px-[24px] mt-[60px] min-h-[calc(100vh-220px)]">
-        <h1 className="text-[var(--text-primary)] leading-tight text-[50px] font-medium m-0 max-w-[760px]">
-          Build event analytics<br />with ScopeDB Cloud
+        <h1 className="text-[var(--text-primary)] leading-tight text-[50px] font-medium m-0">
+          ScopeDB Documentation
         </h1>
-        <div className="text-[var(--text-secondary)] max-w-[660px] text-[20px] font-normal pt-[16px]">
-          ScopeDB Cloud is a serverless database for event analytics. Learn to
-          load, query, model, and retain data with ScopeQL, APIs, and SDKs.
-        </div>
+        <p className="text-[var(--text-secondary)] max-w-[660px] text-[20px] font-normal pt-[16px] m-0">
+          Connect to ScopeDB Cloud and build with ScopeQL, APIs, and SDKs.
+        </p>
 
         <FeaturedItems />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,17 @@
 import Footer from "@/components/Footer";
-import { Metadata } from "next";
+import JsonLd from "@/components/JsonLd";
+import { absoluteUrl, createPageMetadata, SITE_DESCRIPTION, SITE_NAME } from "@/utils/seo";
 import Link from "next/link";
 
-export const metadata: Metadata = {
-  title: "ScopeDB Documentation",
-  description: "Learn how to connect, ingest, query, and build with ScopeDB Cloud",
-}
+const HOME_TITLE = "ScopeDB Docs — Serverless Event Analytics Database";
+
+export const metadata = createPageMetadata({
+  title: HOME_TITLE,
+  description: SITE_DESCRIPTION,
+  pathname: "/",
+  absoluteTitle: true,
+  type: "website",
+});
 
 function FeaturedItems() {
   interface FeaturedItem {
@@ -30,14 +36,14 @@ function FeaturedItems() {
     },
     {
       category: "Work with data",
-      title: "Ingest data",
-      description: "Transform JSON rows with ScopeQL and insert them through the ingest API.",
-      link: "/guides/ingest-events",
+      title: "Query event data",
+      description: "Filter, search, aggregate, and join event data with ScopeQL.",
+      link: "/guides/query-events",
     },
     {
       category: "Work with data",
       title: "Guides",
-      description: "Follow task-focused workflows for ingest, queries, data modeling, and indexes.",
+      description: "Follow task-focused workflows for querying, data modeling, retention, and indexes.",
       link: "/guides",
     },
     {
@@ -56,9 +62,9 @@ function FeaturedItems() {
 
   return (
     <>
-      <div className="text-[var(--text-secondary)] text-[16px] font-normal pt-[60px]">
+      <h2 className="text-[var(--text-secondary)] text-[16px] font-normal pt-[60px]">
         Featured Resources
-      </div>
+      </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mt-6">
         {
           featured.map((item) => (
@@ -70,9 +76,9 @@ function FeaturedItems() {
               <div className="text-[var(--text-tertiary)] text-[12px] font-normal uppercase tracking-wider">
                 {item.category}
               </div>
-              <div className="text-[var(--text-primary)] font-semibold text-[20px] leading-tight">
+              <h3 className="text-[var(--text-primary)] font-semibold text-[20px] leading-tight m-0">
                 {item.title}
-              </div>
+              </h3>
               <div className="text-[var(--text-tertiary)]  text-[14px] leading-relaxed">
                 {item.description}
               </div>
@@ -87,13 +93,24 @@ function FeaturedItems() {
 export default function Home() {
   return (
     <>
+      <JsonLd
+        data={{
+          "@context": "https://schema.org",
+          "@type": "WebSite",
+          "@id": `${absoluteUrl("/")}#website`,
+          name: SITE_NAME,
+          alternateName: "ScopeDB Documentation",
+          url: absoluteUrl("/"),
+          description: SITE_DESCRIPTION,
+        }}
+      />
       <div className="py-[16px] px-[12px] md:px-[24px] mt-[60px] min-h-[calc(100vh-220px)]">
-        <div className="text-[var(--text-primary)] leading-tight text-[50px] font-medium">
-          ScopeDB<br />Documentation
-        </div>
-        <div className="text-[var(--text-secondary)] max-w-[500px] text-[20px] font-normal pt-[16px]">
-          Connect to ScopeDB Cloud, work with your data, and build applications
-          with ScopeQL, APIs, and SDKs.
+        <h1 className="text-[var(--text-primary)] leading-tight text-[50px] font-medium m-0 max-w-[760px]">
+          Build event analytics<br />with ScopeDB Cloud
+        </h1>
+        <div className="text-[var(--text-secondary)] max-w-[660px] text-[20px] font-normal pt-[16px]">
+          ScopeDB Cloud is a serverless database for event analytics. Learn to
+          load, query, model, and retain data with ScopeQL, APIs, and SDKs.
         </div>
 
         <FeaturedItems />

--- a/src/app/reference/[[...slug]]/page.tsx
+++ b/src/app/reference/[[...slug]]/page.tsx
@@ -1,22 +1,34 @@
 import { loadContent } from "@/utils/loader";
 import { loadContentMetadata } from "@/utils/metadata";
+import { getContentPath } from "@/utils/seo";
 import Document from "@/components/Document";
+import { permanentRedirect } from "next/navigation";
 
 export async function generateMetadata({ params }: {
-    params: Promise<{ slug: string }>
-}): Promise<{ title: string }> {
+    params: Promise<{ slug?: string[] }>
+}) {
     const { slug } = await params
     return await loadContentMetadata("reference", slug, { title: "Reference" })
 }
 
 export default async function Reference({ params }: {
-    params: Promise<{ slug: string }>
+    params: Promise<{ slug?: string[] }>
 }) {
     const { slug } = await params
+    if (slug?.at(-1) === "index") {
+        permanentRedirect(getContentPath("reference", slug))
+    }
+
     const { Content, frontmatter, headings } = await loadContent("reference", slug)
     return (
-        <Document headings={headings} relatedContents={frontmatter.relatedContents}>
-            <h1>{frontmatter.title}</h1>
+        <Document
+            headings={headings}
+            relatedContents={frontmatter.relatedContents}
+            title={frontmatter.title}
+            description={frontmatter.description}
+            category="reference"
+            slug={slug}
+        >
             <Content />
         </Document>
     );

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/utils/seo";
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -6,6 +7,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://docs.scopedb.io/sitemap.xml",
+    sitemap: new URL("/sitemap.xml", SITE_URL).toString(),
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,45 +1,29 @@
 import { categories, SidebarItem } from '@/sidebars'
+import { SITE_URL } from '@/utils/seo'
 import type { MetadataRoute } from 'next'
 
-interface SitemapItem {
-    url: string;
-    lastModified: Date;
-    changeFrequency: 'daily' | 'weekly' | 'monthly' | 'yearly';
-    priority: number;
-}
-
 export default function sitemap(): MetadataRoute.Sitemap {
-    const items: SitemapItem[] = []
+    const urls = new Set<string>()
     for (const category of Object.values(categories)) {
-        collectSidebarItems(category.sidebar, items)
+        collectSidebarItems(category.sidebar, urls)
     }
 
     return [
         {
-            url: 'https://docs.scopedb.io',
-            lastModified: new Date(),
-            changeFrequency: 'yearly',
-            priority: 1,
+            url: SITE_URL.toString(),
         },
-        ...items
+        ...Array.from(urls, (url) => ({ url }))
     ]
 }
 
-function collectSidebarItems(items: SidebarItem[], sitemapItems: SitemapItem[]) {
+function collectSidebarItems(items: SidebarItem[], urls: Set<string>) {
     for (const item of items) {
         if (item.link) {
-            sitemapItems.push({
-                url: new URL(item.link, 'https://docs.scopedb.io').toString(),
-                lastModified: new Date(),
-                changeFrequency: 'weekly',
-                priority: 0.8,
-            })
+            urls.add(new URL(item.link, SITE_URL).toString())
         }
 
         if (item.items && item.items.length > 0) {
-            collectSidebarItems(item.items, sitemapItems)
+            collectSidebarItems(item.items, urls)
         }
     }
-
-    return sitemapItems
 }

--- a/src/components/Document/Breadcrumbs.tsx
+++ b/src/components/Document/Breadcrumbs.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+import type { BreadcrumbItem } from "@/utils/seo";
+
+export default function Breadcrumbs({ items }: Readonly<{ items: BreadcrumbItem[] }>) {
+    return (
+        <nav aria-label="Breadcrumb" className="mb-[16px] text-[13px] text-[var(--text-tertiary)]">
+            <ol className="flex flex-wrap items-center gap-x-[8px] gap-y-[4px] list-none m-0 p-0">
+                {items.map((item, index) => {
+                    const isCurrent = index === items.length - 1;
+                    return (
+                        <li key={item.pathname} className="flex items-center gap-[8px]">
+                            {isCurrent ? (
+                                <span aria-current="page">{item.name}</span>
+                            ) : (
+                                <Link
+                                    href={item.pathname}
+                                    className="text-inherit no-underline hover:text-[var(--text-primary)] hover:underline"
+                                >
+                                    {item.name}
+                                </Link>
+                            )}
+                            {!isCurrent && <span aria-hidden="true">/</span>}
+                        </li>
+                    );
+                })}
+            </ol>
+        </nav>
+    );
+}

--- a/src/components/Document/index.tsx
+++ b/src/components/Document/index.tsx
@@ -1,6 +1,16 @@
 import Footer from "@/components/Footer";
+import JsonLd from "@/components/JsonLd";
 import { RelatedContent } from "@/types/frontmatter";
+import {
+    absoluteUrl,
+    type ContentCategory,
+    getBreadcrumbs,
+    getContentPath,
+    SITE_DESCRIPTION,
+    SITE_NAME,
+} from "@/utils/seo";
 import { MarkdownHeading } from "@astrojs/markdown-remark";
+import Breadcrumbs from "./Breadcrumbs";
 import DesktopTableOfContents from "./DesktopTableOfContents";
 import MobileTableOfContents from "./MobileTableOfContents";
 import Sidebar from "@/components/Sidebar";
@@ -8,23 +18,72 @@ import Sidebar from "@/components/Sidebar";
 export default function Document({
     headings,
     relatedContents,
+    title,
+    description,
+    category,
+    slug,
     children,
 }: Readonly<{
     headings: MarkdownHeading[],
     relatedContents?: RelatedContent[],
+    title: string,
+    description?: string,
+    category: ContentCategory,
+    slug?: string[],
     children: React.ReactNode,
 }>) {
-    return (
-        <div className="grid grid-cols-10 gap-[16px]">
-            <div className="col-span-2 hidden lg:block">
-                <div className="sticky top-[140px]">
-                    <Sidebar prefix="doc" className="h-[calc(100vh-140px)] overflow-y-auto" />
-                </div>
-            </div>
+    const pathname = getContentPath(category, slug)
+    const breadcrumbs = getBreadcrumbs(category, pathname, title)
+    const pageUrl = absoluteUrl(pathname)
+    const breadcrumbId = `${pageUrl}#breadcrumb`
 
-            <div className="col-span-10 lg:col-span-6 my-[32px] px-[32px]">
-                <MobileTableOfContents headings={headings} relatedContents={relatedContents} />
-                <div className="
+    return (
+        <>
+            <JsonLd
+                data={{
+                    "@context": "https://schema.org",
+                    "@graph": [
+                        {
+                            "@type": "BreadcrumbList",
+                            "@id": breadcrumbId,
+                            itemListElement: breadcrumbs.map((breadcrumb, index) => ({
+                                "@type": "ListItem",
+                                position: index + 1,
+                                name: breadcrumb.name,
+                                item: absoluteUrl(breadcrumb.pathname),
+                            })),
+                        },
+                        {
+                            "@type": "WebPage",
+                            "@id": pageUrl,
+                            url: pageUrl,
+                            name: title,
+                            description: description || SITE_DESCRIPTION,
+                            breadcrumb: { "@id": breadcrumbId },
+                            isPartOf: {
+                                "@type": "WebSite",
+                                "@id": `${absoluteUrl("/")}#website`,
+                                name: SITE_NAME,
+                                url: absoluteUrl("/"),
+                            },
+                        },
+                    ],
+                }}
+            />
+            <div className="grid grid-cols-10 gap-[16px]">
+                <div className="col-span-2 hidden lg:block">
+                    <div className="sticky top-[140px]">
+                        <Sidebar prefix="doc" className="h-[calc(100vh-140px)] overflow-y-auto" />
+                    </div>
+                </div>
+
+                <div className="col-span-10 lg:col-span-6 my-[32px] px-[32px]">
+                    <Breadcrumbs items={breadcrumbs} />
+                    <h1 className="relative scroll-mt-[80px] text-[32px] font-medium leading-tight text-black mt-0 mb-[24px] [&>code]:[font-size:inherit]">
+                        {title}
+                    </h1>
+                    <MobileTableOfContents headings={headings} relatedContents={relatedContents} />
+                    <div className="
                     w-full max-w-none
                     text-[16px] text-[rgba(0,0,0,0.8)] leading-[1.4]
                     prose
@@ -79,14 +138,15 @@ export default function Document({
                     prose-td:border prose-td:border-[rgba(0,0,0,0.1)] prose-td:p-[12px]
                     prose-hr:my-[32px] prose-hr:border-t prose-hr:border-[rgba(0,0,0,0.1)]
                 ">
-                    {children}
+                        {children}
+                    </div>
+                    <div className="sticky top-full">
+                        <Footer />
+                    </div>
                 </div>
-                <div className="sticky top-full">
-                    <Footer />
-                </div>
-            </div>
 
-            <DesktopTableOfContents headings={headings} relatedContents={relatedContents} />
-        </div>
+                <DesktopTableOfContents headings={headings} relatedContents={relatedContents} />
+            </div>
+        </>
     )
 }

--- a/src/components/Header/MobileNav.tsx
+++ b/src/components/Header/MobileNav.tsx
@@ -181,9 +181,9 @@ export default function MobileNav() {
                     <div className="flex-1 overflow-y-auto">
                         {/* Categories */}
                         <div className="p-4 border-b border-gray-100">
-                            <h3 className="text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider mb-3">
+                            <div className="text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider mb-3">
                                 Categories
-                            </h3>
+                            </div>
                             <div className="space-y-1">
                                 {cs.map((c) => (
                                     <Link key={c.link} href={c.link} onClick={() => setIsOpen(false)} className={
@@ -203,9 +203,9 @@ export default function MobileNav() {
                         {/* Sidebar */}
                         {sidebar && sidebar.length > 0 && (
                             <div className="p-4">
-                                <h3 className="text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider mb-3">
+                                <div className="text-xs font-medium text-[var(--text-tertiary)] uppercase tracking-wider mb-3">
                                     Content
-                                </h3>
+                                </div>
                                 <div className="space-y-1">
                                     {sidebar && <Sidebar prefix="nav" />}
                                 </div>

--- a/src/components/JsonLd.tsx
+++ b/src/components/JsonLd.tsx
@@ -1,0 +1,10 @@
+export default function JsonLd({ data }: Readonly<{ data: object }>) {
+    return (
+        <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+                __html: JSON.stringify(data).replace(/</g, "\\u003c"),
+            }}
+        />
+    );
+}

--- a/src/content/developer/index.mdx
+++ b/src/content/developer/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Developer
+seoTitle: "ScopeDB Developer Docs: SDKs and HTTP API"
+description: Build backend applications with ScopeDB Cloud using the Node.js, Go, or Rust SDK, the HTTP API, or the ScopeQL CLI.
 ---
 
 Build applications and tools on ScopeDB from your backend.

--- a/src/content/developer/sdks.mdx
+++ b/src/content/developer/sdks.mdx
@@ -1,5 +1,6 @@
 ---
 title: SDKs
+seoTitle: ScopeDB SDKs for Node.js, Go, and Rust
 relatedContents:
     - title: Connect an application
       url: /guides/connect-to-scopedb

--- a/src/content/guides/add-indexes.mdx
+++ b/src/content/guides/add-indexes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Add indexes
+seoTitle: Improve ScopeDB Query Performance with Indexes
 relatedContents:
     - title: CREATE INDEX
       url: /reference/commands/statements/create-index

--- a/src/content/guides/authentication.mdx
+++ b/src/content/guides/authentication.mdx
@@ -1,5 +1,7 @@
 ---
 title: Authentication and API keys
+seoTitle: ScopeDB API Key Authentication
+description: Create, store, rotate, and revoke ScopeDB workspace API keys for trusted server-side applications.
 relatedContents:
     - title: Connect an application
       url: /guides/connect-to-scopedb

--- a/src/content/guides/cloud-concepts.mdx
+++ b/src/content/guides/cloud-concepts.mdx
@@ -1,5 +1,6 @@
 ---
 title: ScopeDB Cloud concepts
+seoTitle: ScopeDB Cloud Concepts
 relatedContents:
     - title: Connect an application
       url: /guides/connect-to-scopedb

--- a/src/content/guides/connect-to-scopedb.mdx
+++ b/src/content/guides/connect-to-scopedb.mdx
@@ -1,5 +1,7 @@
 ---
 title: Connect an application
+seoTitle: Connect an Application to ScopeDB Cloud
+description: Connect a backend application to ScopeDB Cloud using the API address and a workspace API key from the Console.
 relatedContents:
     - title: ScopeDB Cloud concepts
       url: /guides/cloud-concepts

--- a/src/content/guides/data-retention.mdx
+++ b/src/content/guides/data-retention.mdx
@@ -1,5 +1,6 @@
 ---
 title: Set data retention
+seoTitle: Set Event Data Retention in ScopeDB
 relatedContents:
     - title: CREATE TABLE
       url: /reference/commands/statements/create-table

--- a/src/content/guides/index.mdx
+++ b/src/content/guides/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Guides
+seoTitle: ScopeDB Event Analytics Guides
+description: Follow task-focused guides to connect ScopeDB Cloud, query and model event data, set retention, manage access, and improve query performance.
 ---
 
 Use these guides to get oriented in ScopeDB Cloud, connect a client, and complete

--- a/src/content/guides/ingest-events.mdx
+++ b/src/content/guides/ingest-events.mdx
@@ -1,5 +1,7 @@
 ---
 title: Ingest data
+seoTitle: Ingest Event Data into ScopeDB
+description: Learn the current ingest API workflow for sending event rows to a ScopeDB table.
 relatedContents:
     - title: Connect an application
       url: /guides/connect-to-scopedb

--- a/src/content/guides/model-flexible-events.mdx
+++ b/src/content/guides/model-flexible-events.mdx
@@ -1,5 +1,6 @@
 ---
 title: Model semi-structured data
+seoTitle: Model Semi-Structured Event Data
 relatedContents:
     - title: Semi-structured data type
       url: /reference/data-types/semi-structured

--- a/src/content/guides/query-events.mdx
+++ b/src/content/guides/query-events.mdx
@@ -1,5 +1,6 @@
 ---
 title: Query data
+seoTitle: Query Event Data with ScopeQL
 relatedContents:
     - title: Query syntax
       url: /reference/commands/stmt-query

--- a/src/content/guides/quickstart.mdx
+++ b/src/content/guides/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: Quickstart
+seoTitle: "ScopeDB Quickstart: Query Event Data with ScopeQL"
 relatedContents:
     - title: Connect an application
       url: /guides/connect-to-scopedb

--- a/src/content/reference/commands/index.mdx
+++ b/src/content/reference/commands/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: ScopeDB command reference
+seoTitle: ScopeQL Commands and Query Syntax
+description: Reference ScopeQL query pipelines, operators, and data definition and manipulation statements for working with data in ScopeDB.
 ---
 
 These topics provide reference information for all the ScopeDB commands (DDL, DML, and query syntax).

--- a/src/content/reference/commands/stmt-query.mdx
+++ b/src/content/reference/commands/stmt-query.mdx
@@ -1,5 +1,6 @@
 ---
 title: Query syntax
+description: Reference the ScopeQL query pipeline, including FROM, SELECT, WHERE, JOIN, AGGREGATE, ORDER BY, and LIMIT clauses.
 ---
 
 ScopeDB supports querying using a pipelined relational query language (ScopeQL) in the following basic syntax:

--- a/src/content/reference/data-types/index.mdx
+++ b/src/content/reference/data-types/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Data types reference
+seoTitle: ScopeQL Data Types Reference
+description: Learn ScopeQL scalar, temporal, semi-structured, and conversion data types and how each type behaves in ScopeDB queries.
 ---
 
 ScopeDB is strongly typed, and each value has a specific data type. The data type of a value determines how it can be used in queries and what operations can be performed on it.

--- a/src/content/reference/functions/aggregate/max.mdx
+++ b/src/content/reference/functions/aggregate/max.mdx
@@ -13,10 +13,6 @@ max( <expr> )
 max( <expr>, <n> )
 ```
 
-## Returns
-
-The data type of the returned value is the same as the data type of the input values.
-
 ## Arguments
 
 **Required:**

--- a/src/content/reference/functions/index.mdx
+++ b/src/content/reference/functions/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Functions reference
+seoTitle: ScopeQL Functions Reference
+description: Reference ScopeQL aggregate, scalar, window, string, numeric, date and time, and semi-structured data functions.
 ---
 
 These topics provide reference information for the system-defined functions.

--- a/src/content/reference/functions/string/ltrim.mdx
+++ b/src/content/reference/functions/string/ltrim.mdx
@@ -22,11 +22,11 @@ One or more characters to remove from the left side of `<expr>`.
 
 The default value is `" \t\n\r"` (common whitespace characters).
 
-### Returns
+## Returns
 
 This function returns a value of string data type or NULL. If either argument is NULL, returns NULL.
 
-### Examples
+## Examples
 
 Remove leading `0` and `#` characters from a string:
 

--- a/src/content/reference/functions/string/rtrim.mdx
+++ b/src/content/reference/functions/string/rtrim.mdx
@@ -22,11 +22,11 @@ One or more characters to remove from the right side of `<expr>`.
 
 The default value is `" \t\n\r"` (common whitespace characters).
 
-### Returns
+## Returns
 
 This function returns a value of string data type or NULL. If either argument is NULL, returns NULL.
 
-### Examples
+## Examples
 
 Remove trailing `0` and `.` characters from a string:
 

--- a/src/content/reference/functions/string/trim.mdx
+++ b/src/content/reference/functions/string/trim.mdx
@@ -22,11 +22,11 @@ One or more characters to remove from the left and right side of `<expr>`.
 
 The default value is `" \t\n\r"` (common whitespace characters).
 
-### Returns
+## Returns
 
 This function returns a value of string data type or NULL. If either argument is NULL, returns NULL.
 
-### Examples
+## Examples
 
 Remove leading and trailing * and - characters from a string:
 

--- a/src/content/reference/index.mdx
+++ b/src/content/reference/index.mdx
@@ -1,18 +1,22 @@
 ---
 title: Reference
+seoTitle: ScopeQL Language Reference
+description: Look up ScopeQL query syntax, statements, operators, data types, and functions for filtering, transforming, and analyzing data in ScopeDB.
 ---
 
-Reference information on various areas of ScopeDB.
+Use this reference to look up ScopeQL query pipelines, statements, operators,
+data types, and functions. ScopeQL is ScopeDB's language for filtering,
+transforming, and analyzing data.
 
-### [Data type reference](/reference/data-types)
+## [Data type reference](/reference/data-types)
 
 Reference for ScopeDB data types.
 
-### [Command reference](/reference/commands)
+## [Command reference](/reference/commands)
 
 Reference for ScopeDB query syntax, DDL, DML, indexes, and inspection
 statements.
 
-### [Function reference](/reference/functions)
+## [Function reference](/reference/functions)
 
 Reference for ScopeDB functions.

--- a/src/plugins/remark-frontmatter-mdx.ts
+++ b/src/plugins/remark-frontmatter-mdx.ts
@@ -5,6 +5,71 @@ import { type Plugin } from 'unified'
 import { define } from 'unist-util-mdx-define'
 import { parse as parseYaml } from 'yaml'
 
+const MAX_DESCRIPTION_LENGTH = 160
+
+interface TextNode {
+    type?: string
+    value?: unknown
+    alt?: unknown
+    children?: unknown[]
+}
+
+function nodeText(node: unknown): string {
+    if (!node || typeof node !== 'object') {
+        return ''
+    }
+
+    const { type, value, alt, children } = node as TextNode
+    if ((type === 'text' || type === 'inlineCode') && typeof value === 'string') {
+        return value
+    }
+
+    if (type === 'image' && typeof alt === 'string') {
+        return alt
+    }
+
+    return Array.isArray(children) ? children.map(nodeText).join('') : ''
+}
+
+function findFirstParagraph(node: unknown): unknown | undefined {
+    if (!node || typeof node !== 'object') {
+        return undefined
+    }
+
+    const { type, children } = node as TextNode
+    if (type === 'paragraph') {
+        return node
+    }
+
+    if (Array.isArray(children)) {
+        for (const child of children) {
+            const paragraph = findFirstParagraph(child)
+            if (paragraph) {
+                return paragraph
+            }
+        }
+    }
+
+    return undefined
+}
+
+function deriveDescription(ast: Root): string | undefined {
+    const paragraph = findFirstParagraph(ast)
+    const text = nodeText(paragraph).replace(/\s+/g, ' ').trim()
+    if (!text) {
+        return undefined
+    }
+
+    if (text.length <= MAX_DESCRIPTION_LENGTH) {
+        return text
+    }
+
+    const truncated = text.slice(0, MAX_DESCRIPTION_LENGTH - 1)
+    const lastSpace = truncated.lastIndexOf(' ')
+    const end = lastSpace > 80 ? lastSpace : truncated.length
+    return `${truncated.slice(0, end).trim()}…`
+}
+
 const plugin: Plugin<[define.Options?], Root> = ({
     ...options
 } = {}) => {
@@ -19,11 +84,20 @@ const plugin: Plugin<[define.Options?], Root> = ({
     return (ast, file) => {
         const node = ast.children.find((child) => Object.hasOwn(allParsers, child.type))
 
-        let data = undefined
+        let data: Record<string, unknown> | undefined
         if (node) {
             const parser = allParsers[node.type]
             const { value } = node as Literal
-            data = parser(value)
+            const parsed = parser(value)
+            const frontmatterData: Record<string, unknown> = parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+                ? { ...parsed }
+                : {}
+
+            if (!frontmatterData.description) {
+                frontmatterData.description = deriveDescription(ast)
+            }
+
+            data = frontmatterData
 
             // HACK - collaborate with `@astrojs/markdown-remark`
             file.data.astro = { frontmatter: data }

--- a/src/types/frontmatter.ts
+++ b/src/types/frontmatter.ts
@@ -1,5 +1,7 @@
 export interface FrontmatterProps {
     title: string;
+    seoTitle?: string;
+    description?: string;
     relatedContents?: RelatedContent[];
 }
 

--- a/src/utils/metadata.ts
+++ b/src/utils/metadata.ts
@@ -1,16 +1,33 @@
+import type { Metadata } from "next"
 import { loadContent } from "./loader"
+import {
+    createPageMetadata,
+    getContentPath,
+    getContentSeoTitle,
+    SITE_DESCRIPTION,
+} from "./seo"
 
 export interface ContentMetadata {
     title: string
+    description?: string
 }
 
 export async function loadContentMetadata(
     category: string,
     slug: string | string[] | null | undefined,
     fallback: ContentMetadata
-): Promise<ContentMetadata> {
+): Promise<Metadata> {
     const { frontmatter } = await loadContent(category, slug)
-    return {
-        title: frontmatter.title || fallback.title,
-    }
+    const title = getContentSeoTitle(
+        category,
+        slug,
+        frontmatter.title || fallback.title,
+        frontmatter.seoTitle,
+    )
+
+    return createPageMetadata({
+        title,
+        description: frontmatter.description || fallback.description || SITE_DESCRIPTION,
+        pathname: getContentPath(category, slug),
+    })
 }

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -1,0 +1,179 @@
+import type { Metadata } from "next";
+import { categories, type SidebarItem } from "@/sidebars";
+
+export const SITE_URL = new URL("https://docs.scopedb.io");
+export const SITE_NAME = "ScopeDB Docs";
+export const SITE_DESCRIPTION =
+    "Learn how to load, query, model, and retain event data with ScopeDB Cloud, the serverless database for event analytics. Explore ScopeQL, SDKs, and APIs.";
+
+export type ContentCategory = keyof typeof categories;
+
+const SOCIAL_IMAGE = {
+    url: new URL("/opengraph-image", SITE_URL).toString(),
+    width: 1200,
+    height: 630,
+    alt: "ScopeDB Docs — serverless database for event analytics",
+};
+
+const functionGroups: Record<string, string> = {
+    aggregate: "Aggregate",
+    "conditional-expression": "Conditional expression",
+    "date-and-time": "Date and time",
+    numeric: "Numeric",
+    string: "String",
+    "semi-structured-data": "Semi-structured",
+    system: "System",
+    window: "Window",
+};
+
+function slugSegments(slug: string | string[] | null | undefined): string[] {
+    const segments = Array.isArray(slug) ? slug : slug ? [slug] : [];
+    return segments.at(-1) === "index" ? segments.slice(0, -1) : segments;
+}
+
+export function getContentPath(
+    category: string,
+    slug: string | string[] | null | undefined,
+): string {
+    return `/${[category, ...slugSegments(slug)].join("/")}`;
+}
+
+export function getContentSeoTitle(
+    category: string,
+    slug: string | string[] | null | undefined,
+    title: string,
+    seoTitle?: string,
+): string {
+    if (seoTitle) {
+        return seoTitle;
+    }
+
+    const segments = slugSegments(slug);
+    if (category !== "reference") {
+        return title;
+    }
+
+    if (segments[0] === "functions" && segments.length >= 3) {
+        const group = functionGroups[segments[1]];
+        if (group) {
+            return `${title} — ${group} function`;
+        }
+    }
+
+    if (segments[0] === "commands" && segments[1] === "statements" && segments.length >= 3) {
+        return `${title} — ScopeQL statement`;
+    }
+
+    if (segments[0] === "commands" && segments[1] === "query-operators" && segments.length >= 3) {
+        return `${title} — ScopeQL operators`;
+    }
+
+    return title;
+}
+
+export function createPageMetadata({
+    title,
+    description,
+    pathname,
+    absoluteTitle = false,
+    type = "article",
+}: {
+    title: string;
+    description: string;
+    pathname: string;
+    absoluteTitle?: boolean;
+    type?: "article" | "website";
+}): Metadata {
+    const titleAlreadyIncludesBrand = /\bScopeDB\b/i.test(title);
+    const useAbsoluteTitle = absoluteTitle || titleAlreadyIncludesBrand;
+    const socialTitle = useAbsoluteTitle ? title : `${title} | ${SITE_NAME}`;
+
+    return {
+        title: useAbsoluteTitle ? { absolute: title } : title,
+        description,
+        alternates: {
+            canonical: pathname,
+        },
+        openGraph: {
+            type,
+            locale: "en_US",
+            siteName: SITE_NAME,
+            title: socialTitle,
+            description,
+            url: pathname,
+            images: [SOCIAL_IMAGE],
+        },
+        twitter: {
+            card: "summary_large_image",
+            title: socialTitle,
+            description,
+            images: [SOCIAL_IMAGE.url],
+        },
+    };
+}
+
+export interface BreadcrumbItem {
+    name: string;
+    pathname: string;
+}
+
+function findSidebarTrail(
+    items: SidebarItem[],
+    pathname: string,
+    parents: SidebarItem[] = [],
+): SidebarItem[] | undefined {
+    for (const item of items) {
+        if (item.link === pathname) {
+            return [...parents, item];
+        }
+
+        if (item.items) {
+            const trail = findSidebarTrail(item.items, pathname, [...parents, item]);
+            if (trail) {
+                return trail;
+            }
+        }
+    }
+
+    return undefined;
+}
+
+function sidebarItemPath(item: SidebarItem): string | undefined {
+    if (item.link) {
+        return item.link;
+    }
+
+    return item.items?.find((child) => child.label === "Overview" && child.link)?.link;
+}
+
+export function getBreadcrumbs(
+    category: ContentCategory,
+    pathname: string,
+    title: string,
+): BreadcrumbItem[] {
+    const categoryConfig = categories[category];
+    const trail = findSidebarTrail(categoryConfig.sidebar, pathname) ?? [];
+    const breadcrumbs: BreadcrumbItem[] = [{ name: "Docs", pathname: "/" }];
+
+    if (pathname !== categoryConfig.link) {
+        breadcrumbs.push({ name: categoryConfig.label, pathname: categoryConfig.link });
+    }
+
+    for (const item of trail.slice(0, -1)) {
+        const itemPath = sidebarItemPath(item);
+        if (!itemPath || itemPath === categoryConfig.link || itemPath === pathname) {
+            continue;
+        }
+
+        if (!breadcrumbs.some((breadcrumb) => breadcrumb.pathname === itemPath)) {
+            breadcrumbs.push({ name: item.label, pathname: itemPath });
+        }
+    }
+
+    breadcrumbs.push({ name: title, pathname });
+    return breadcrumbs;
+}
+
+export function absoluteUrl(pathname: string): string {
+    return new URL(pathname, SITE_URL).toString();
+}


### PR DESCRIPTION
## Summary

- add shared site and page metadata with canonical URLs, unique SEO titles, descriptions, Open Graph, and Twitter cards
- strengthen the homepage and major hubs around ScopeDB Cloud as a serverless database for event analytics
- derive page descriptions from MDX content while allowing explicit frontmatter overrides
- add visible breadcrumbs with matching WebSite, WebPage, and BreadcrumbList structured data
- add a generated 1200x630 social image and align robots, sitemap, and llms discovery files
- redirect duplicate `/index` aliases and remove synthetic sitemap modification dates
- improve homepage and reference heading semantics without exposing deployment or internal architecture details

## Why

The documentation was crawlable, but most pages only emitted a bare title. Content pages had no descriptions, canonical URLs, social metadata, or structured data; several function references shared identical titles; and the sitemap reported every page as newly modified on each build.

The homepage also did not express ScopeDB's serverless event analytics positioning in its primary heading and gave the legacy ingest workflow disproportionate internal-link prominence.

## User impact

Search engines and link previews now receive accurate, page-specific metadata. Users also get clearer document hierarchy and task-oriented discovery, while the public documentation remains focused on the managed ScopeDB Cloud product.

## Validation

- `pnpm exec opennextjs-cloudflare build`
- clean OpenNext Cloudflare preview
- verified all 131 sitemap URLs return 200
- verified 131 unique titles with descriptions, canonical URLs, social metadata, structured data, and exactly one H1
- verified description punctuation and whitespace
- verified top-level and nested `/index` aliases return 308
- verified `/robots.txt`, `/sitemap.xml`, and the generated social image
- verified missing pages return 404 with a single `noindex` directive
- `git diff --check`

## Post-deploy checks

- confirm production `/robots.txt` is served after deployment
- configure or verify the canonical HTTP-to-HTTPS redirect at the Cloudflare edge